### PR TITLE
Several updates (inputFile, allHLT, only one triggers loop in the code)

### DIFF
--- a/RatePlots/doAll.sh
+++ b/RatePlots/doAll.sh
@@ -1,0 +1,7 @@
+python3 trigger_plots.py --xsect --vsIntLumi --inputFile /afs/cern.ch/work/s/sdonato/public/OMS_ntuples/v2.0/goldejson_skim.root --triggers allL1 --selections "PU45_55=pileup>45 && pileup<55" --nbins 10000 >& logAllL1Plots &
+python3 trigger_plots.py --xsect --vsIntLumi --inputFile /afs/cern.ch/work/s/sdonato/public/OMS_ntuples/v2.0/goldejson_skim.root --triggers allHLT --selections "PU45_55=pileup>45 && pileup<55" --nbins 10000 >& logAllHLTPlots &
+
+
+python3 trigger_plots.py --xsect --vsPU --inputFile /afs/cern.ch/work/s/sdonato/public/OMS_ntuples/v2.0/goldejson_skim.root --removeOutliers 0.005 --triggers allL1 --selections "RunFG=run>360389" --lumisPerBin 10 >& logAllL1PlotsVsPU &
+python3 trigger_plots.py --xsect --vsPU --inputFile /afs/cern.ch/work/s/sdonato/public/OMS_ntuples/v2.0/goldejson_skim.root --removeOutliers 0.001 --triggers allHLT --selections "RunFG=run>360389" --lumisPerBin 100 >& logAllHLTPlotsVsPU &
+

--- a/RatePlots/doAll2018.sh
+++ b/RatePlots/doAll2018.sh
@@ -1,0 +1,7 @@
+python3 trigger_plots.py --xsect --vsIntLumi --inputFile /afs/cern.ch/work/s/sdonato/public/OMS_ntuples/v2.0/2018/2018.root --triggers allL1 --selections "2018_PU45_55=pileup>45 && pileup<55 && physics_flag && hbhea && hbhec && hbheb && bpix && fpix" --nbins 10000 >& logAllL1Plots2018 &
+python3 trigger_plots.py --xsect --vsIntLumi --inputFile /afs/cern.ch/work/s/sdonato/public/OMS_ntuples/v2.0/2018/2018.root --triggers allHLT --selections "2018_PU45_55=pileup>45 && pileup<55 && physics_flag && hbhea && hbhec && hbheb && bpix && fpix" --nbins 10000 >& logAllHLTPlots2018 &
+
+
+python3 trigger_plots.py --xsect --vsPU --inputFile /afs/cern.ch/work/s/sdonato/public/OMS_ntuples/v2.0/2018/2018.root --removeOutliers 0.005 --triggers allL1 --selections "2018=physics_flag && hbhea && hbhec && hbheb && bpix && fpix" --lumisPerBin 10 >& logAllL1PlotsVsPU2018 &
+python3 trigger_plots.py --xsect --vsPU --inputFile /afs/cern.ch/work/s/sdonato/public/OMS_ntuples/v2.0/2018/2018.root --removeOutliers 0.001 --triggers allHLT --selections "2018=physics_flag && hbhea && hbhec && hbheb && bpix && fpix" --lumisPerBin 100 >& logAllHLTPlotsVsPU2018 &
+

--- a/RatePlots/tools.py
+++ b/RatePlots/tools.py
@@ -161,15 +161,16 @@ def readOptions(args, triggers, selections):
     if args.vsIntLumi: vses.append("vsIntLumi")
     if args.vsTime: vses.append("vsTime")
     if len(useRates) == 0:
-        print("adding --xsect flag (--xsect or --rates is required)")
+        print("adding default --xsect flag (--xsect or --rates is required)")
         useRates.append(False)
     if len(vses) == 0:
-        print("adding --vsIntLumi flag (at least one --vs* is required)")
+        print("adding default --vsIntLumi flag (at least one --vs* is required)")
         vses.append("vsIntLumi")
     runMin = int(args.runMin)
     runMax = int(args.runMax)
     removeOutliers = float(args.removeOutliers)
-    folder = args.input
+    inputFolder = args.input
+    inputFile = args.inputFile
     plotFolder = args.output
     if args.triggers: triggers = args.triggers.split(",")
     if args.selections:
@@ -183,6 +184,10 @@ def readOptions(args, triggers, selections):
     lumisPerBin = int(args.lumisPerBin)
     nbins = int(args.nbins)
     if nbins>0 and lumisPerBin>0: raise Exception("You have to use one and only one option between --lumisPerBin and --nbins.")
+    if not inputFile and not inputFolder: 
+        inputFile = "/afs/cern.ch/work/s/sdonato/public/OMS_ntuples/v2.0/goldejson_skim.root"
+        print ("Using default inputFile = %s"%inputFile)
+    if inputFolder and inputFile:  raise Exception("You cannot --input and --inputFolder at the same time.")
     print(args)
-    return useRates, vses, triggers, folder, plotFolder, removeOutliers, runMin, runMax, batch, testing, lumisPerBin, refLumi, selections, nbins
+    return useRates, vses, triggers, inputFolder, inputFile, plotFolder, removeOutliers, runMin, runMax, batch, testing, lumisPerBin, refLumi, selections, nbins
 


### PR DESCRIPTION
- support `--inputFile` 
- support `--triggers allHLT,allL1`
- do not keep plots in memory (ie. [get Hitsto -> get Xsect -> make plot]  per each plots) [Big changes in the for loops within the code]
- fix in `--lumisPerBins` and `--nBins`
- speed up (move Scale inside getCrosssection)
- add doAll*.sh script to make all plots of 2018 and 2022